### PR TITLE
Switching to cleaner method of canonicalizing code coverage paths

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+# .coveragerc to control coverage.py
+[run]
+source = ingredient_phrase_tagger
+
+; Run in parallel mode so that coverage can canonicalize the source paths
+; regardless of whether it runs locally or within a Docker container.
+parallel = True
+
+[paths]
+; the first path is the path on the local filesystem
+; the second path is the path as it appears within the Docker container
+source =
+  ingredient_phrase_tagger/
+  /app/ingredient_phrase_tagger/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 build
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ python:
 services: docker
 script: ./docker_build
 after_success:
+after_success:
   - pip install pyyaml coveralls
-  - docker cp ingredient-phrase-tagger-container:/ingredient-phrase-tagger/.coverage ./
-  # Fix paths in .coverage so they match Coveralls' expectations of Travis'
-  # paths.
-  - sed -i "s@\"/ingredient-phrase-tagger/@\"${PWD}/@g" .coverage
+  # Copy the .coverage.* file from the Docker container to the local filesystem.
+  - docker cp ingredient-phrase-tagger-container:/app/$(docker exec -it ingredient-phrase-tagger-container bash -c "ls -a .coverage.*" | tr -d '\r') ./
+  # Use coverage combine to canonicalize the source paths.
+  - coverage combine
+  # Upload coverage information to Coveralls.
   - coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update -y && \
     apt-get install -y git python2.7 python-pip
 
-ADD . /ingredient-phrase-tagger
-WORKDIR /ingredient-phrase-tagger
+ADD . /app
+WORKDIR /app
 
 RUN python setup.py install
 

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,6 @@ find . -name "*.pyc" -delete
 
 # Run unit tests and calculate code coverage.
 coverage run \
-  --source "ingredient_phrase_tagger" \
   -m unittest discover
 
 # Check that source has correct formatting.


### PR DESCRIPTION
The previous method used hacky regexes to tamper with the .coverage file. This method uses supported features of the coverage binary to create a coverage file within the Docker container, then use "coverage combine" outside the container so that coverage canonicalizes all of the source file paths to match how they look on the local filesystem.