### PR TITLE
Adding tokenizer handling for milliliters

### DIFF
--- a/ingredient_phrase_tagger/training/tokenizer.py
+++ b/ingredient_phrase_tagger/training/tokenizer.py
@@ -18,6 +18,7 @@ def tokenize(s):
     # handle abbreviation like "100g" by treating it as "100 grams"
     s = re.sub(r'(\d+)g', r'\1 grams', s)
     s = re.sub(r'(\d+)oz', r'\1 ounces', s)
+    s = re.sub(r'(\d+)ml', r'\1 milliliters', s, flags=re.IGNORECASE)
 
     american_units = [
         'cup', 'tablespoon', 'teaspoon', 'pound', 'ounce', 'quart', 'pint'

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -18,6 +18,8 @@ class TokenizerTest(unittest.TestCase):
         pairs = [
             ('100g melted chocolate', ['100', 'grams', 'melted', 'chocolate']),
             ('8oz diet coke', ['8', 'ounces', 'diet', 'coke']),
+            ('15ml coconut oil', ['15', 'milliliters', 'coconut', 'oil']),
+            ('15mL coconut oil', ['15', 'milliliters', 'coconut', 'oil']),
         ]
         for ingredient, tokens_expected in pairs:
             tokens_actual = tokenizer.tokenize(ingredient)


### PR DESCRIPTION
Add handling to the tokenizer for token sequences like '15ml' so that the tokenizer knows to split it up into quantity and unit.