### PR TITLE
Remove redundant Dockerfile cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 
 RUN apt-get update -y && \
     apt-get install -y git python2.7 python-pip && \
-    rm -rf /var/lib/apt/lists/* &&
+    rm -Rf /usr/share/doc && \
+    rm -Rf /usr/share/man && \
+    rm -rf /var/lib/apt/lists/*
 
 ADD . /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -y && \
     apt-get install -y git python2.7 python-pip && \
     rm -Rf /usr/share/doc && \
     rm -Rf /usr/share/man && \
+    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 ADD . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,10 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.schema-version="1.0.0-rc1"
 
 RUN apt-get update -y && \
-    apt-get install -y git python2.7 python-pip
+    apt-get install -y git python2.7 python-pip && \
+    rm -rf /var/lib/apt/lists/* &&
 
 ADD . /app
 WORKDIR /app
 
 RUN python2 setup.py install
-
-# Clean up.
-RUN rm -rf /var/lib/apt/lists/* && \
-    rm -Rf /usr/share/doc && \
-    rm -Rf /usr/share/man && \
-    apt-get autoremove -y && \
-    apt-get clean


### PR DESCRIPTION
Running apt cleanup steps in a separate Docker layer doesn't make the image smaller, so I combined this with the apt-get install line.

See: https://github.com/waleedka/modern-deep-learning-docker/issues/4

I also removed the autoremove and cleanup commands, because according to the [official documentation](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run), these are run after every install for official Ubuntu images (which this is based on).

> Official Debian and Ubuntu images automatically run apt-get clean, so explicit invocation is not required.