### PR TITLE
Move yapf excluded folders into a .yapfignore file

### DIFF
--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,2 @@
+third_party/*
+build/*

--- a/build.sh
+++ b/build.sh
@@ -20,9 +20,7 @@ yapf \
   --diff \
   --recursive \
   --style google \
-  ./ \
-  --exclude="third_party/*" \
-  --exclude="build/*"
+  ./
 
 # Run static analysis for Python bugs/cruft.
 pyflakes bin/ ingredient_phrase_tagger/


### PR DESCRIPTION
Move yapf excluded folders into a .yapfignore file so that executing yapf from the command-line on its own doesn't require providing all the excludes again. Can also add an autoformat script that calls yapf and will obey the same excludes.