### PR TITLE
Fix stdin encoding bug

### DIFF
--- a/bin/parse-ingredients.py
+++ b/bin/parse-ingredients.py
@@ -14,7 +14,7 @@ def _exec_crf_test(input_text, model_path):
         input_file.write(utils.export_data(input_text))
         input_file.flush()
         return subprocess.check_output(
-            ['crf_test', '--verbose=1', '--model', model_path, input_file.name])
+            ['crf_test', '--verbose=1', '--model', model_path, input_file.name]).decode('utf-8')
 
 
 def _convert_crf_output_to_json(crf_output):

--- a/bin/parse-ingredients.py
+++ b/bin/parse-ingredients.py
@@ -14,7 +14,8 @@ def _exec_crf_test(input_text, model_path):
         input_file.write(utils.export_data(input_text))
         input_file.flush()
         return subprocess.check_output(
-            ['crf_test', '--verbose=1', '--model', model_path, input_file.name]).decode('utf-8')
+            ['crf_test', '--verbose=1', '--model', model_path,
+             input_file.name]).decode('utf-8')
 
 
 def _convert_crf_output_to_json(crf_output):


### PR DESCRIPTION
The subprocess module in Python 3 does not automatically decode its input, and instead returns a bytestring. We don't want to work on bytes, but instead we want to deal with unicode strings. This change just decodes the subprocess output so we can deal with unicode and not bytes.

Fixes https://github.com/mtlynch/ingredient-phrase-tagger/issues/79